### PR TITLE
Address $4e8b is not part of the high score

### DIFF
--- a/releases/Alibaba 40 Thieves.mra
+++ b/releases/Alibaba 40 Thieves.mra
@@ -46,12 +46,12 @@
 
    <rom index="3" md5="none">
     <part>
-	    00 00 4E 88 04 00 00 00
+	    00 00 4E 88 03 00 00 00
 	    00 00 43 ED 06 40 40 00
 	    00 00 43 D1 01 48 48 00
 	</part>
 
    </rom>	
-   <nvram index="4" size="11"/>
+   <nvram index="4" size="10"/>
    
 </misterromdescription>

--- a/releases/Ms. Pacman.mra
+++ b/releases/Ms. Pacman.mra
@@ -39,12 +39,12 @@
 
    <rom index="3" md5="none">
     <part>
-	    00 00 4E 88 04 00 00 00
+	    00 00 4E 88 03 00 00 00
 	    00 00 43 ED 06 40 40 00
 	    00 00 43 D1 01 48 48 00
 	</part>
 
    </rom>	
-   <nvram index="4" size="11"/>
+   <nvram index="4" size="10"/>
    
 </misterromdescription>

--- a/releases/Pac-Man (Midway).mra
+++ b/releases/Pac-Man (Midway).mra
@@ -36,13 +36,13 @@
 
    <rom index="3" md5="none">
     <part>
-	    00 00 4E 88 04 00 00 00
+	    00 00 4E 88 03 00 00 00
 	    00 00 43 ED 06 40 40 00
 	    00 00 43 D1 01 48 48 00
 	</part>
 
    </rom>	
-   <nvram index="4" size="11"/>
+   <nvram index="4" size="10"/>
    
    
 </misterromdescription>

--- a/releases/Pacman Club.mra
+++ b/releases/Pacman Club.mra
@@ -36,14 +36,14 @@
 	
 	<rom index="3" md5="none">
     <part>
-	    00 00 4E 88 04 00 00 00
+	    00 00 4E 88 03 00 00 00
 	    00 00 43 ED 06 40 40 00
 	    00 00 43 D1 01 59 59 00
 		00 00 43 CB 0A 4F 4D 00
 	</part>
 
    </rom>	
-   <nvram index="4" size="21"/>
+   <nvram index="4" size="20"/>
 
 
 	

--- a/releases/Pacman Plus.mra
+++ b/releases/Pacman Plus.mra
@@ -38,12 +38,12 @@
 	
    <rom index="3" md5="none">
     <part>
-	    00 00 4E 88 04 00 00 00
+	    00 00 4E 88 03 00 00 00
 	    00 00 43 ED 06 40 40 00
 	    00 00 43 D1 01 48 48 00
 	</part>
 
    </rom>	
-   <nvram index="4" size="11"/>	
+   <nvram index="4" size="10"/>
 	
 </misterromdescription>

--- a/releases/Puck Man (Japan set 1).mra
+++ b/releases/Puck Man (Japan set 1).mra
@@ -50,13 +50,13 @@
 	
 	<rom index="3" md5="none">
     <part>
-	    00 00 4E 88 04 00 00 00
+	    00 00 4E 88 03 00 00 00
 	    00 00 43 ED 06 40 40 00
 	    00 00 43 D1 01 48 48 00
 	</part>
 
    </rom>	
-   <nvram index="4" size="11"/>
+   <nvram index="4" size="10"/>
 	
 	
 </misterromdescription>


### PR DESCRIPTION
I don't believe $4e8b is used in the standard Pac-Man ROMs so it may not be a problem but it's not part of the high score at least.